### PR TITLE
feat: 모임 기능 추가

### DIFF
--- a/src/main/java/thundergather/thundergatherbe/auth/config/SecurityConfig.java
+++ b/src/main/java/thundergather/thundergatherbe/auth/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package thundergather.thundergatherbe.auth.config;
 
 import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.PATCH;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.HttpMethod.PUT;
 import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
@@ -67,8 +69,10 @@ public class SecurityConfig {
             List<RequestMatcher> requestMatchers = List.of(
                     antMatcher("/api/v1/member"),
                     antMatcher(POST, "/api/v1/post"),
-                    antMatcher(PUT, "/api/v1/post"),
-                    antMatcher(DELETE, "/api/v1/post")
+                    antMatcher(PATCH, "/api/v1/post"),
+                    antMatcher(DELETE, "/api/v1/post"),
+                    antMatcher(POST, "/api/v1/meeting"),
+                    antMatcher(GET, "/api/v1/meeting")
             );
             return requestMatchers.toArray(RequestMatcher[]::new);
       }

--- a/src/main/java/thundergather/thundergatherbe/global/exception/type/ErrorCode.java
+++ b/src/main/java/thundergather/thundergatherbe/global/exception/type/ErrorCode.java
@@ -26,6 +26,10 @@ public enum ErrorCode {
       ALREADY_UNLIKED(HttpStatus.BAD_REQUEST, "이미 좋아요를 취소한 게시물입니다."),
       NICKNAME_DUPLICATION(HttpStatus.BAD_REQUEST, "이미 사용중인 닉네임입니다."),
       PASSWORD_EMPTY(HttpStatus.BAD_REQUEST, "비밀번호를 입력해주세요."),
+      OVER_MAX_PARTICIPANTS(HttpStatus.BAD_REQUEST, "모임 최대 인원수를 초과했습니다."),
+
+      // Meeting error
+      DUPLICATE_MEETING(HttpStatus.BAD_REQUEST, "이미 모임에 참여하셨습니다."),
       /**
        * 401 Unauthorized
        */
@@ -38,7 +42,6 @@ public enum ErrorCode {
       UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 토큰입니다."),
       WRONG_TYPE_TOKEN(HttpStatus.UNAUTHORIZED, "잘못된 유형의 토큰입니다."),
       EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다. 재발급이 필요합니다."),
-
 
       /**
        * 404 Not Found

--- a/src/main/java/thundergather/thundergatherbe/meeting/repository/MeetingRepository.java
+++ b/src/main/java/thundergather/thundergatherbe/meeting/repository/MeetingRepository.java
@@ -4,9 +4,17 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import thundergather.thundergatherbe.meeting.entity.Meeting;
+import thundergather.thundergatherbe.member.entity.Member;
+import thundergather.thundergatherbe.post.entity.Post;
 
 @Repository
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
       List<Meeting> findByPostId(Long postId);
+
+      boolean existsByPostAndMember(Post post, Member member);
+
+      List<Meeting> findByMemberId(Long memberId);
+
+      void deleteByPostAndMember(Post post, Member member);
 }

--- a/src/main/java/thundergather/thundergatherbe/member/service/MeetingService.java
+++ b/src/main/java/thundergather/thundergatherbe/member/service/MeetingService.java
@@ -1,0 +1,14 @@
+package thundergather.thundergatherbe.member.service;
+
+import java.util.List;
+import thundergather.thundergatherbe.post.dto.PostListResponse;
+import thundergather.thundergatherbe.post.dto.PostResponse;
+
+public interface MeetingService {
+
+    PostResponse applyMeeting(Long postId, String email);
+
+    List<PostListResponse> myMeetingList(String email);
+
+    void cancelMeeting(Long postId, String email);
+}

--- a/src/main/java/thundergather/thundergatherbe/member/service/impl/MeetingServiceImpl.java
+++ b/src/main/java/thundergather/thundergatherbe/member/service/impl/MeetingServiceImpl.java
@@ -1,0 +1,98 @@
+package thundergather.thundergatherbe.member.service.impl;
+
+import static thundergather.thundergatherbe.global.exception.type.ErrorCode.DUPLICATE_MEETING;
+import static thundergather.thundergatherbe.global.exception.type.ErrorCode.OVER_MAX_PARTICIPANTS;
+import static thundergather.thundergatherbe.global.exception.type.ErrorCode.POST_NOT_FOUND;
+import static thundergather.thundergatherbe.global.exception.type.ErrorCode.USER_NOT_FOUND;
+import static thundergather.thundergatherbe.global.exception.type.ErrorCode.WRITE_NOT_YOURSELF;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import thundergather.thundergatherbe.global.exception.GlobalException;
+import thundergather.thundergatherbe.meeting.entity.Meeting;
+import thundergather.thundergatherbe.meeting.repository.MeetingRepository;
+import thundergather.thundergatherbe.member.entity.Member;
+import thundergather.thundergatherbe.member.repository.MemberRepository;
+import thundergather.thundergatherbe.member.service.MeetingService;
+import thundergather.thundergatherbe.post.dto.PostListResponse;
+import thundergather.thundergatherbe.post.dto.PostResponse;
+import thundergather.thundergatherbe.post.entity.Post;
+import thundergather.thundergatherbe.post.repository.PostRepository;
+
+@Service
+@RequiredArgsConstructor
+public class MeetingServiceImpl implements MeetingService {
+
+      private final MeetingRepository meetingRepository;
+      private final MemberRepository memberRepository;
+      private final PostRepository postRepository;
+
+      @Override
+      public PostResponse applyMeeting(Long postId, String email) {
+            Post post = getPost(postId);
+            Member member = getMember(email);
+
+            // 멤버가 이미 신청했다면 중복 에러 처리
+            if (meetingRepository.existsByPostAndMember(post, member)) {
+                  throw new GlobalException(DUPLICATE_MEETING);
+            }
+            // 모임 최대 인원수가 넘었는지 확인
+            if (post.getMeetingMembers().size() >= post.getMaxParticipants()) {
+                  throw new GlobalException(OVER_MAX_PARTICIPANTS);
+            }
+            // 모임 신청
+            Meeting meeting = Meeting.builder()
+                    .post(post)
+                    .member(member)
+                    .author(false)
+                    .build();
+
+            // 모임, 멤버, 포스트에 추가
+            meeting.addPostAndMember(post, member);
+
+            meetingRepository.save(meeting);
+
+            return PostResponse.fromEntity(post);
+      }
+
+      @Override
+      public List<PostListResponse> myMeetingList(String email) {
+            Member member = getMember(email);
+
+            // 내가 참가한 모임 리스트
+            return meetingRepository.findByMemberId(member.getId()).stream()
+                    .map(Meeting::getPost)
+                    .map(PostListResponse::fromEntity)
+                    .toList();
+      }
+
+      @Transactional
+      @Override
+      public void cancelMeeting(Long postId, String email) {
+            Post post = getPost(postId);
+            Member member = getMember(email);
+
+            // 모임에 참가한 멤버가 아니라면 에러 처리
+            if (!meetingRepository.existsByPostAndMember(post, member)) {
+                  throw new GlobalException(WRITE_NOT_YOURSELF);
+            }
+
+            // 모임 신청 취소
+            meetingRepository.deleteByPostAndMember(post, member);
+      }
+
+
+
+      private Post getPost(Long postId) {
+            return postRepository.findById(postId)
+                    .orElseThrow(() -> new GlobalException(POST_NOT_FOUND));
+      }
+
+      private Member getMember(String email) {
+
+            return memberRepository.findByEmail(email)
+                    .orElseThrow(() -> new GlobalException(USER_NOT_FOUND));
+      }
+}

--- a/src/main/java/thundergather/thundergatherbe/member/web/MeetingController.java
+++ b/src/main/java/thundergather/thundergatherbe/member/web/MeetingController.java
@@ -1,0 +1,40 @@
+package thundergather.thundergatherbe.member.web;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import thundergather.thundergatherbe.auth.config.LoginUser;
+import thundergather.thundergatherbe.member.service.MeetingService;
+import thundergather.thundergatherbe.post.dto.PostResponse;
+
+@RestController
+@RequestMapping("/api/v1/meeting")
+@RequiredArgsConstructor
+public class MeetingController {
+
+      private final MeetingService meetingService;
+
+      @PostMapping(path = "/{postId}", produces = MediaType.APPLICATION_JSON_VALUE)
+      public ResponseEntity<PostResponse> applyMeeting(@PathVariable Long postId, @LoginUser String email) {
+            return ResponseEntity.ok(meetingService.applyMeeting(postId, email));
+      }
+
+      @GetMapping(path = "/mymeeting", produces = MediaType.APPLICATION_JSON_VALUE)
+      public ResponseEntity<?> myMeetingList(@LoginUser String email) {
+            return ResponseEntity.ok(meetingService.myMeetingList(email));
+      }
+
+      @DeleteMapping(path = "/{postId}", produces = MediaType.APPLICATION_JSON_VALUE)
+      public ResponseEntity<?> cancelMeeting(@PathVariable Long postId, @LoginUser String email) {
+            meetingService.cancelMeeting(postId, email);
+            return ResponseEntity.ok("모임 취소 성공");
+      }
+
+
+}


### PR DESCRIPTION


### 변경사항
<!-- 이 PR에서 어떤 점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->

**AS-IS**
- 모임 신청, 취소, 조회 기능 미구현

**TO-BE**
- 모임 기능 추가:
  - **모임 신청 기능**
    - 사용자는 특정 게시물에 대해 모임을 신청할 수 있습니다.
    - 모임 신청 시, 중복 신청 및 최대 인원 초과에 대한 예외 처리가 포함됩니다.
  - **모임 취소 기능**
    - 사용자는 자신이 신청한 모임을 취소할 수 있습니다.
  - **모임 조회 기능**
    - 사용자는 자신이 신청한 모든 모임을 조회할 수 있습니다.

### 주요 변경 파일
1. **SecurityConfig.java**
    - 모임 관련 엔드포인트에 대한 권한 설정 추가
2. **ErrorCode.java**
    - 중복 모임 신청, 최대 인원 초과 예외 코드 추가
3. **MeetingRepository.java**
    - 모임 리포지토리 인터페이스 추가 및 모임 조회, 존재 여부 확인 메서드 추가
4. **MeetingService.java**
    - 모임 서비스 인터페이스 추가
5. **MeetingServiceImpl.java**
    - 모임 서비스 구현체 추가: 모임 신청, 조회, 취소 로직 구현
6. **MeetingController.java**
    - 모임 관련 API 엔드포인트 추가: 모임 신청, 조회, 취소 기능

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 모임 신청 API 테스트 완료
- [x] 모임 취소 API 테스트 완료
- [x] 모임 조회 API 테스트 완료
- [x] 중복 모임 신청 예외 처리 테스트 완료
- [x] 최대 참가자 수 초과 예외 처리 테스트 완료
