### PR TITLE
feat: CORS 설정 추가

### DIFF
--- a/src/main/java/thundergather/thundergatherbe/global/config/WebMvcConfig.java
+++ b/src/main/java/thundergather/thundergatherbe/global/config/WebMvcConfig.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import thundergather.thundergatherbe.auth.config.LoginUserArgumentResolver;
 
@@ -18,4 +19,17 @@ public class WebMvcConfig implements WebMvcConfigurer {
             // loginUserArgumentResolver 를 Argument Resolver 목록에 추가
             resolvers.add(loginUserArgumentResolver);
       }
+
+      @Override
+      public void addCorsMappings(CorsRegistry registry) {
+            registry.addMapping("/**")
+                    .allowedOrigins("https://main--beo-gather.netlify.app")  // 여기서 요청을 허용할 출처를 지정
+                    .allowedOrigins("http://localhost:5173")  // 여기서 요청을 허용할 출처를 지정
+                    .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS",
+                            "PATCH")  // 허용할 HTTP 메소드 지정
+                    .allowedHeaders("*")  // 모든 헤더 허용
+                    .allowCredentials(true)  // 쿠키를 포함한 요청 허용
+                    .maxAge(3600);  // preflight 리퀘스트를 캐싱할 시간 지정
+      }
+
 }


### PR DESCRIPTION
- 특정 출처에서의 요청을 허용하는 CORS 설정을 추가했습니다.
- 허용할 HTTP 메소드와 헤더를 지정하고, 쿠키를 포함한 요청을 허용하도록 설정했습니다.
- preflight 요청을 3600초 동안 캐싱하도록 변경했습니다.